### PR TITLE
Add arbitrum keepers

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -3,6 +3,7 @@ name: keepers
 plugins:
   - name: optimism
   - name: base
+  - name: arbitrum
   - name: alchemy
   - name: foundry
 
@@ -16,6 +17,15 @@ optimism:
     transaction_acceptance_timeout: 120
 
 base:
+  default_network: sepolia
+  sepolia:
+    default_provider: alchemy
+    transaction_acceptance_timeout: 120
+  mainnet:
+    default_provider: alchemy
+    transaction_acceptance_timeout: 120
+
+arbitrum:
   default_network: sepolia
   sepolia:
     default_provider: alchemy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,17 @@
 version: '3'
 
 services:
+  # order-keeper-arb-sepolia-octo:
+  #   restart: always
+  #   build: .
+  #   env_file: .env_order_arb_sepolia_octo
+  #   entrypoint: ["silverback", "run", "testnet_octopus:app", "--network", "arbitrum:sepolia:alchemy", "--runner", "silverback.runner:WebsocketRunner"]
+
   # order-keeper-sepolia:
   #   restart: always
   #   build: .
   #   env_file: .env_order_sepolia
-  #   entrypoint: ["silverback", "run", "main:app", "--network", "base:sepolia:alchemy", "--runner", "silverback.runner:WebsocketRunner"]
+  #   entrypoint: ["silverback", "run", "testnet:app", "--network", "base:sepolia:alchemy", "--runner", "silverback.runner:WebsocketRunner"]
 
   # liq-keeper-sepolia:
   #   restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-dotenv
 ipykernel
 eth-ape==0.8.9
 silverback==0.4.1
--e git+https://git@github.com/Synthetixio/python-sdk.git@a786549f0de039d001a8ca58a3408faca49e4584#egg=synthetix&subdirectory=src
+synthetix==0.1.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dotenv
 ipykernel
 eth-ape==0.8.9
-silverback==0.4.2
-synthetix==0.1.13
+silverback==0.4.1
+-e git+https://git@github.com/Synthetixio/python-sdk.git@a786549f0de039d001a8ca58a3408faca49e4584#egg=synthetix&subdirectory=src

--- a/testnet.py
+++ b/testnet.py
@@ -1,0 +1,83 @@
+# silverback run main:app --network base:mainnet:alchemy --runner silverback.runner:WebsocketRunner
+import os
+import time
+from dotenv import load_dotenv
+from ape import chain, Contract
+from ape.api import BlockAPI
+from synthetix import Synthetix
+from utils.swap import assemble_transaction
+
+from silverback import SilverbackApp
+
+# load the environment variables
+load_dotenv('.env')
+
+ADDRESS = os.environ.get("ADDRESS")
+PRIVATE_KEY = os.environ.get("PRIVATE_KEY")
+
+# constants
+DELAY_SECONDS = 0
+
+
+# init snx
+snx = Synthetix(
+    provider_rpc=chain.provider.uri,
+    private_key=PRIVATE_KEY,
+    address=ADDRESS,
+    is_fork=chain.provider.name == "foundry",
+)
+print(snx.network_id)
+
+# Do this to initialize your app
+app = SilverbackApp()
+
+# Get the perps proxy contract
+PerpsMarket = Contract(
+    address=snx.perps.market_proxy.address, abi=snx.perps.market_proxy.abi
+)
+
+
+# Perps orders
+# settle perps order function
+def settle_perps_order(event):
+    account_id = event["accountId"]
+    market_id = event["marketId"]
+    market_name = snx.perps.markets_by_id[market_id]["market_name"]
+
+    # add a delay
+    snx.logger.info(f"{market_name} Order committed by {account_id}")
+    time.sleep(DELAY_SECONDS)
+
+    order = snx.perps.get_order(account_id)
+    if order["size_delta"] != 0:
+        snx.logger.info(f"Settling {market_name} order committed by {account_id}")
+        order_settlement_tx = snx.perps.settle_order(account_id, submit=False)
+
+        # double the base fee
+        order_settlement_tx["maxFeePerGas"] = order_settlement_tx["maxFeePerGas"] * 2
+        tx_hash = snx.execute_transaction(order_settlement_tx)
+        tx_receipt = snx.wait(tx_hash)
+
+        if tx_receipt["status"] == 1:
+            snx.logger.info(
+                f"Keeper settled {market_name} order committed by {account_id}"
+            )
+        else:
+            snx.logger.error(
+                f"Keeper failed to settle {market_name} order committed by {account_id}"
+            )
+    else:
+        snx.logger.info(f"Keeper settled {market_name} order committed by {account_id}")
+
+
+@app.on_(PerpsMarket.OrderCommitted, new_block_timeout=60)
+def perps_order_committed(event):
+    settle_perps_order(event)
+    return {"message": f"Perps order committed: {event}"}
+
+
+# check balance and swap
+# Log new blocks
+@app.on_(chain.blocks, new_block_timeout=60)
+def exec_block(block: BlockAPI):
+    snx.logger.info(f"Block number: {block.number}")

--- a/testnet_octopus.py
+++ b/testnet_octopus.py
@@ -1,0 +1,88 @@
+# silverback run main:app --network base:mainnet:alchemy --runner silverback.runner:WebsocketRunner
+import os
+import time
+from dotenv import load_dotenv
+from ape import chain, Contract
+from ape.api import BlockAPI
+from synthetix import Synthetix
+from utils.swap import assemble_transaction
+
+from silverback import SilverbackApp
+
+# load the environment variables
+load_dotenv('.env')
+
+ADDRESS = os.environ.get("ADDRESS")
+PRIVATE_KEY = os.environ.get("PRIVATE_KEY")
+
+# constants
+DELAY_SECONDS = 0
+
+
+# init snx
+snx = Synthetix(
+    provider_rpc=chain.provider.uri,
+    private_key=PRIVATE_KEY,
+    address=ADDRESS,
+    is_fork=chain.provider.name == "foundry",
+    cannon_config={
+        'package': "synthetix-omnibus",
+        "version": "latest",
+        "preset": "octopus"
+    }
+)
+print(snx.network_id)
+
+# Do this to initialize your app
+app = SilverbackApp()
+
+# Get the perps proxy contract
+PerpsMarket = Contract(
+    address=snx.perps.market_proxy.address, abi=snx.perps.market_proxy.abi
+)
+
+
+# Perps orders
+# settle perps order function
+def settle_perps_order(event):
+    account_id = event["accountId"]
+    market_id = event["marketId"]
+    market_name = snx.perps.markets_by_id[market_id]["market_name"]
+
+    # add a delay
+    snx.logger.info(f"{market_name} Order committed by {account_id}")
+    time.sleep(DELAY_SECONDS)
+
+    order = snx.perps.get_order(account_id)
+    if order["size_delta"] != 0:
+        snx.logger.info(f"Settling {market_name} order committed by {account_id}")
+        order_settlement_tx = snx.perps.settle_order(account_id, submit=False)
+
+        # double the base fee
+        order_settlement_tx["maxFeePerGas"] = order_settlement_tx["maxFeePerGas"] * 2
+        tx_hash = snx.execute_transaction(order_settlement_tx)
+        tx_receipt = snx.wait(tx_hash)
+
+        if tx_receipt["status"] == 1:
+            snx.logger.info(
+                f"Keeper settled {market_name} order committed by {account_id}"
+            )
+        else:
+            snx.logger.error(
+                f"Keeper failed to settle {market_name} order committed by {account_id}"
+            )
+    else:
+        snx.logger.info(f"Keeper settled {market_name} order committed by {account_id}")
+
+
+@app.on_(PerpsMarket.OrderCommitted, new_block_timeout=60)
+def perps_order_committed(event):
+    settle_perps_order(event)
+    return {"message": f"Perps order committed: {event}"}
+
+
+# check balance and swap
+# Log new blocks
+@app.on_(chain.blocks, new_block_timeout=60)
+def exec_block(block: BlockAPI):
+    snx.logger.info(f"Block number: {block.number}")


### PR DESCRIPTION
- Split testnet keeper into a different file
  - Testnet keeper doesn't include a "swap" component on Odos
  - Testnet keeper delay is set to zero
- Add specific app for octopus deployment keeper
- Update `silverback` and `synthetix` versions in requirements 
