### PR TITLE
Update packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Base image
-FROM ghcr.io/astral-sh/uv:0.4.18-debian
+FROM python:3.12-slim
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN apt-get update && apt-get install -y curl clang gcc python3-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
 
 # Create app directory
 WORKDIR /app
@@ -12,11 +12,7 @@ COPY pyproject.toml .
 COPY ape-config.yaml .
 
 # Install dependencies
-RUN uv python install
 RUN uv sync --frozen
-ENV PATH="/app/.venv/bin:$PATH"
-
-# Install ape plugins
 RUN uv run ape plugins install .
 
 # Copy app source code

--- a/docker-compose.prices.yml
+++ b/docker-compose.prices.yml
@@ -12,6 +12,4 @@ services:
         "prices",
         "--network",
         "base:mainnet:node",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
       ]

--- a/docker-compose.sepolia.yml
+++ b/docker-compose.sepolia.yml
@@ -12,8 +12,6 @@ services:
         "perps_v3",
         "--network",
         "base:sepolia:node",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
       ]
 
   keeper-arb-sepolia:
@@ -29,8 +27,6 @@ services:
         "perps_v3",
         "--network",
         "arbitrum:sepolia:alchemy",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
       ]
 
   keeper-eth-sepolia:
@@ -46,6 +42,4 @@ services:
         "perps_bfp",
         "--network",
         "ethereum:sepolia:node",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,7 @@ services:
         "run",
         "perps_v3",
         "--network",
-        "base:mainnet:node",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
+        "base:mainnet:alchemy",
       ]
 
   keeper-arb-mainnet:
@@ -29,8 +27,6 @@ services:
         "perps_v3",
         "--network",
         "arbitrum:mainnet:alchemy",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
       ]
 
   keeper-eth-mainnet:
@@ -46,6 +42,4 @@ services:
         "perps_bfp",
         "--network",
         "ethereum:mainnet:node",
-        "--runner",
-        "silverback.runner:WebsocketRunner",
       ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "A collection of keepers for Synthetix contracts"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "eth-ape==0.8.20",
+    "eth-ape==0.8.22",
     "python-dotenv>=1.0.1",
-    "silverback==0.6.4",
-    "synthetix>=0.1.21",
+    "silverback==0.6.5",
+    "synthetix>=0.1.22",
 ]


### PR DESCRIPTION
- Use `python-3.12` image instead of uv image
- Copy uv from uv image
- Update `pyproject.toml` with new version of synthetix, silverback, and ape
- Remove websocket runner from all images, since it will be inferred from the provided RPC